### PR TITLE
Add Revise.jl

### DIFF
--- a/revise/Project.toml
+++ b/revise/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/revise/revise_load_script.jl
+++ b/revise/revise_load_script.jl
@@ -1,0 +1,14 @@
+import Pkg
+Pkg.instantiate()
+
+using Revise
+
+Pkg.activate(dirname(@__DIR__))
+Pkg.resolve()
+Pkg.instantiate()
+
+using HydroPowerModels
+@info("""
+This session is using HydroPowerModels with Revise.jl.
+For more information visit https://timholy.github.io/Revise.jl/stable/.
+""")

--- a/revise/revise_session.bat
+++ b/revise/revise_session.bat
@@ -1,0 +1,5 @@
+@echo off
+
+SET REVISE_PATH=%~dp0
+
+julia --color=yes --project=%REVISE_PATH% --load=%REVISE_PATH%\revise_load_script.jl


### PR DESCRIPTION
- Add Revise.jl

When starting the Julia session for development, use revised/revise_load script.jl, this way you will not need to close and open the Julia session after modifying the package.