### PR TITLE
fix minimal volume constraint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HydroPowerModels"
 uuid = "1bf2e10f-7293-4f36-bafb-f7584ca75eae"
 authors = ["andrewrosemberg <andrewrosemberg@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/examples/HydroValleys/case3deterministic.jl
+++ b/examples/HydroValleys/case3deterministic.jl
@@ -57,3 +57,54 @@ results = HydroPowerModels.simulate(m, 1);
     0.6243,
     atol=1e-2,
 )
+
+########################################
+#       Build Model: min vol violation
+########################################
+for data in alldata
+    data["hydro"]["Hydrogenerators"][1]["min_volume"] = 0.2
+    data["hydro"]["Hydrogenerators"][1]["minimal_volume_violation_cost"] = 10000000
+end
+
+m = hydro_thermal_operation(alldata, params)
+
+########################################
+#       Solve
+########################################
+HydroPowerModels.train(m; iteration_limit=60);
+
+########################################
+#       Simulation
+########################################
+results = HydroPowerModels.simulate(m, 1);
+
+########################################
+#       Test
+########################################
+@test results[:simulations][1][end][:reservoirs][:reservoir][1].out >= 0.2
+
+########################################
+#       Build Model: min turb violation
+########################################
+for data in alldata
+    data["hydro"]["Hydrogenerators"][1]["min_volume"] = 0.0
+    data["hydro"]["Hydrogenerators"][1]["minimal_volume_violation_cost"] = 0.0
+    data["hydro"]["Hydrogenerators"][1]["min_volume"] = 5.0
+    data["hydro"]["Hydrogenerators"][1]["minimal_outflow_violation_cost"] = 10000000
+end
+m = hydro_thermal_operation(alldata, params)
+
+########################################
+#       Solve
+########################################
+HydroPowerModels.train(m; iteration_limit=60);
+
+########################################
+#       Simulation
+########################################
+results = HydroPowerModels.simulate(m, 1);
+
+########################################
+#       Test
+########################################
+@test results[:simulations][1][end][:reservoirs][:outflow][1] >= 5

--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -96,7 +96,7 @@ function constraint_min_volume_violation(sp, data::Dict)
         sp,
         min_volume_violation_bound[r=1:data["hydro"]["nHyd"]],
         sp[:min_volume_violation][r] >=
-            (data["hydro"]["Hydrogenerators"][r]["min_turn"] - sp[:reservoir][r].out)
+            (data["hydro"]["Hydrogenerators"][r]["min_volume"] - sp[:reservoir][r].out)
     )
     return nothing
 end


### PR DESCRIPTION
The minimum volume restriction was using the minimum turbine value. This commit fixes this and adds 2 tests. One for the minimum volume restriction and the other for the minimum turbine restriction.