### PR TITLE
Pin Documenter to v0.27

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -18,3 +18,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 Weave = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
+
+[compat]
+Documenter = "0.27"


### PR DESCRIPTION
Documentation was failing in #16, likely because of this.